### PR TITLE
440 SessionTimeout: Client Session Expired Must Log In Again

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,41 @@ var reason = new HttpStatusMessage(code);
 // or use implicit cast
 var reason:HttpStatusMessage = code;
 ```
+
+## Unofficial codes
+
+HttpStatusCode contains the current official specifications for HTTP status code.
+
+There exist other unofficial codes, that can be regrouped by categories (Microsoft, Nginx and so on). Overlap is very small right now but there are added in the `httpstatus.unofficial` package anyway.
+
+Only the `Microsoft.hx` http status codes are implemented right now.
+Feel free to PR for others.
+
+```haxe
+import httpstatus.HttpStatusCode;
+import httpstatus.HttpStatusMessage;
+import httpstatus.unofficial.Microsoft;
+
+var code    : Microsoft         = SessionTimeout;   // 440
+var code2   : HttpStatusCode    = SessionTimeout;   // 440
+
+var reason  : HttpStatusMessage = SessionTimeout;   // "Client Session Expired Must Log In Again"
+var reason2 : HttpStatusMessage = code;             // "Client Session Expired Must Log In Again"
+// but:
+var reason3 : HttpStatusMessage = code2;            // "Unknown Status". This is a limitation 
+```
+
+## With tink
+
+There are automatic `#if tink_core` fences in the code, so this does not require it.
+
+Producing these error codes on a server using [tink](https://github.com/haxetink/tink_core) is straightforward.
+When getting a `tink.core.Error` on the client, one can use `switch (e.code : HttpStatusCode)`.
+If your server chose to use some exotic status code such as 440 SessionTimeout (Microsoft), you can use something like:
+
+```haxe
+switch (e.code : httpstatus.unofficial.Microsoft) {
+    case SessionTimeout:
+    case Forbidden:         // regular codes from HttpStatusCode are also available
+}
+```

--- a/haxelib.json
+++ b/haxelib.json
@@ -10,8 +10,8 @@
 	"contributors": [
 		"kevinresol"
 	],
-	"releasenote": "toInt is necessary",
-	"version": "1.3.1",
+	"releasenote": "add 440 Client Session Expired Need Log In Again",
+	"version": "1.3.2",
 	"url": "https://github.com/kevinresol/http-status",
 	"dependencies": {}
 }

--- a/src/httpstatus/HttpStatusCode.hx
+++ b/src/httpstatus/HttpStatusCode.hx
@@ -52,7 +52,7 @@ abstract HttpStatusCode(Int) from Int {
 	var PreconditionRequired = 428;
 	var TooManyRequests = 429;
 	var RequestHeaderFieldsTooLarge = 431;
-	var SessionTimeout = 440;
+	// var SessionTimeout = 440;            // look into httpstatus.unofficial.Microsoft!
 	var UnavailableForLegalReasons = 451;
 	var InternalServerError = 500;
 	var NotImplemented = 501;

--- a/src/httpstatus/HttpStatusCode.hx
+++ b/src/httpstatus/HttpStatusCode.hx
@@ -52,7 +52,10 @@ abstract HttpStatusCode(Int) from Int {
 	var PreconditionRequired = 428;
 	var TooManyRequests = 429;
 	var RequestHeaderFieldsTooLarge = 431;
-	// var SessionTimeout = 440;            // look into httpstatus.unofficial.Microsoft!
+	// var SessionTimeout = 440;             // see Microsoft.hx
+	// var RetryWith = 449;                  // see Microsoft.hx
+	// var BlockedByParentalControl = 450;   // see Microsoft.hx
+	// var ExchangeActiveSyncRedirect = 451; // see Microsoft.hx
 	var UnavailableForLegalReasons = 451;
 	var InternalServerError = 500;
 	var NotImplemented = 501;

--- a/src/httpstatus/HttpStatusCode.hx
+++ b/src/httpstatus/HttpStatusCode.hx
@@ -52,6 +52,7 @@ abstract HttpStatusCode(Int) from Int {
 	var PreconditionRequired = 428;
 	var TooManyRequests = 429;
 	var RequestHeaderFieldsTooLarge = 431;
+	var SessionTimeout = 440;
 	var UnavailableForLegalReasons = 451;
 	var InternalServerError = 500;
 	var NotImplemented = 501;

--- a/src/httpstatus/HttpStatusMessage.hx
+++ b/src/httpstatus/HttpStatusMessage.hx
@@ -56,6 +56,7 @@ abstract HttpStatusMessage(String) from String to String {
 			case 428: 'Precondition Required';
 			case 429: 'Too Many Requests';
 			case 431: 'Request Header Fields Too Large';
+			case 440: 'Client Session Expired Must Log In Again';
 			case 451: 'Unavailable For Legal Reasons';
 			case 500: 'Internal Server Error';
 			case 501: 'Not Implemented';

--- a/src/httpstatus/HttpStatusMessage.hx
+++ b/src/httpstatus/HttpStatusMessage.hx
@@ -56,7 +56,10 @@ abstract HttpStatusMessage(String) from String to String {
 			case 428: 'Precondition Required';
 			case 429: 'Too Many Requests';
 			case 431: 'Request Header Fields Too Large';
-			// case 440: 'Client Session Expired Must Log In Again';    // look into httpstatus.unofficial.Microsoft!
+			// case 440: 'Client Session Expired Must Log In Again';       // see Microsoft.hx
+			// case 449: 'User Has Not Provided The Required Information'; // see Microsoft.hx
+			// case 450: 'Blocked By Parental Control';                    // see Microsoft.hx
+			// case 451: 'Exchange ActiveSync Redirect';                   // see Microsoft.hx
 			case 451: 'Unavailable For Legal Reasons';
 			case 500: 'Internal Server Error';
 			case 501: 'Not Implemented';

--- a/src/httpstatus/HttpStatusMessage.hx
+++ b/src/httpstatus/HttpStatusMessage.hx
@@ -56,7 +56,7 @@ abstract HttpStatusMessage(String) from String to String {
 			case 428: 'Precondition Required';
 			case 429: 'Too Many Requests';
 			case 431: 'Request Header Fields Too Large';
-			case 440: 'Client Session Expired Must Log In Again';
+			// case 440: 'Client Session Expired Must Log In Again';    // look into httpstatus.unofficial.Microsoft!
 			case 451: 'Unavailable For Legal Reasons';
 			case 500: 'Internal Server Error';
 			case 501: 'Not Implemented';

--- a/src/httpstatus/unofficial/Microsoft.hx
+++ b/src/httpstatus/unofficial/Microsoft.hx
@@ -1,0 +1,18 @@
+package httpstatus.unofficial;
+
+import httpstatus.HttpStatusCode;
+import httpstatus.HttpStatusMessage;
+
+@:enum
+abstract Microsoft(HttpStatusCode) from HttpStatusCode {
+
+    var SessionTimeout = 440;
+
+    @:to public function toStatusCode():HttpStatusCode return this;
+    @:to public function toStatusMessage():HttpStatusMessage {
+        return switch this {
+            case 440: 'Client Session Expired Must Log In Again';
+            default: this.toMessage();
+        } 
+    }
+}

--- a/src/httpstatus/unofficial/Microsoft.hx
+++ b/src/httpstatus/unofficial/Microsoft.hx
@@ -25,7 +25,8 @@ abstract Microsoft(HttpStatusCode) from HttpStatusCode {
     }
 
     #if tink_core
-    @:from public static inline function fromErrorCode(code:tink.core.Error.ErrorCode):Microsoft return (code:Int);
+    @:from public static inline function fromErrorCode(code:tink.core.Error.ErrorCode):Microsoft 
+        return HttpStatusCode.fromErrorCode((code:Int));
     #end
 
 }

--- a/src/httpstatus/unofficial/Microsoft.hx
+++ b/src/httpstatus/unofficial/Microsoft.hx
@@ -24,4 +24,8 @@ abstract Microsoft(HttpStatusCode) from HttpStatusCode {
         }
     }
 
+    #if tink_core
+    @:from public static inline function fromErrorCode(code:tink.core.Error.ErrorCode):Microsoft return (code:Int);
+    #end
+
 }

--- a/src/httpstatus/unofficial/Microsoft.hx
+++ b/src/httpstatus/unofficial/Microsoft.hx
@@ -8,6 +8,8 @@ abstract Microsoft(HttpStatusCode) from HttpStatusCode {
 
     var SessionTimeout = 440;
 
+    @:to public function toInt() : Int return this;
+
     @:to public function toStatusCode():HttpStatusCode return this;
     @:to public function toStatusMessage():HttpStatusMessage {
         return switch this {
@@ -15,4 +17,5 @@ abstract Microsoft(HttpStatusCode) from HttpStatusCode {
             default: this.toMessage();
         } 
     }
+
 }

--- a/src/httpstatus/unofficial/Microsoft.hx
+++ b/src/httpstatus/unofficial/Microsoft.hx
@@ -6,7 +6,10 @@ import httpstatus.HttpStatusMessage;
 @:enum
 abstract Microsoft(HttpStatusCode) from HttpStatusCode {
 
-    var SessionTimeout = 440;
+    var SessionTimeout             = 440; // The client's session has expired and must log in again
+    var RetryWith                  = 449; // The server cannot honour the request because the user has not provided the required information
+    var BlockedByParentalControl   = 450; // When Windows Parental Controls are turned on and are blocking access
+    var ExchangeActiveSyncRedirect = 451; // Used in Exchange ActiveSync when either a more efficient server is available or the server cannot access the users' mailbox.[84] The client is expected to re-run the HTTP AutoDiscover operation to find a more appropriate server.
 
     @:to public function toInt() : Int return this;
 
@@ -14,8 +17,11 @@ abstract Microsoft(HttpStatusCode) from HttpStatusCode {
     @:to public function toStatusMessage():HttpStatusMessage {
         return switch this {
             case 440: 'Client Session Expired Must Log In Again';
+            case 449: 'User Has Not Provided The Required Information';
+            case 450: 'Blocked By Parental Control';
+            case 451: 'Exchange ActiveSync Redirect'; 
             default: this.toMessage();
-        } 
+        }
     }
 
 }


### PR DESCRIPTION
Usage is not widespread as this is a code used by Microsoft.

See https://stackoverflow.com/questions/1653493/what-http-status-code-is-supposed-to-be-used-to-tell-the-client-the-session-has/22484262#22484262
Or https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#440

However, given the frequent usage of Promises with tink,
seems to me a good idea to have this error code, for better *discrimination*.

For instance, if one was to sanitize http error messages when passing in Production (erase message and override the default message from the error code), having a mere 401 would be problematic, while a 440 would make things clear.
